### PR TITLE
Add XML file paths in window title upon saving and loading repositories.

### DIFF
--- a/SatellaWave/SatellaWave/MainWindow.cs
+++ b/SatellaWave/SatellaWave/MainWindow.cs
@@ -18,6 +18,15 @@ namespace SatellaWave
             this.Text = "SatellaWave " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString();
         }
 
+        public void setTitle(string fileName)
+        {
+            this.Text = "SatellaWave " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            if (fileName != "")
+            {
+                this.Text += " [" + fileName + "]";
+            }
+        }
+
         /* MENU */
 
         private void quitToolStripMenuItem_Click(object sender, EventArgs e)

--- a/SatellaWave/SatellaWave/Program.cs
+++ b/SatellaWave/SatellaWave/Program.cs
@@ -115,6 +115,7 @@ namespace SatellaWave
             AddChannel(2);
 
             lastSavedXMLFile = "";
+            mainWindow.setTitle("");
         }
 
         public static void AddChannel(Channel _chn)
@@ -914,6 +915,7 @@ namespace SatellaWave
             }
 
             lastSavedXMLFile = xmlPath;
+            mainWindow.setTitle(xmlPath);
         }
 
         public static void SaveBSXRepository()
@@ -1082,6 +1084,7 @@ namespace SatellaWave
             xmlWriter.Close();
 
             lastSavedXMLFile = filepath;
+            mainWindow.setTitle(filepath);
         }
 
         public static void ExportBSX(string folderPath)


### PR DESCRIPTION
This PR will add the XML file path of the currently loaded or the recently saved repositories to the SatellaWave window. It will clear out when starting a fresh repository.

This will be quite handy while dealing with multiple repositories.