### PR TITLE
Fix SNES Patch channel not reading correctly from XML repository.

### DIFF
--- a/SatellaWave/SatellaWave/Program.cs
+++ b/SatellaWave/SatellaWave/Program.cs
@@ -1121,13 +1121,13 @@ namespace SatellaWave
                                     }
 
                                     patchchn.SetFilePath(nodeChannel.ChildNodes[0].Attributes["filePath"].Value);
-
-                                    TreeNode patchnode = new TreeNode(patchchn.name + " (" + patchchn.GetChannelNumberString() + ")");
-                                    patchnode.Tag = patchchn;
-                                    patchnode.ContextMenuStrip = mainWindow.contextMenuStripChannelMenu;
-
-                                    nodelist.Add(patchnode);
                                 }
+
+                                TreeNode patchnode = new TreeNode(patchchn.name + " (" + patchchn.GetChannelNumberString() + ")");
+                                patchnode.Tag = patchchn;
+                                patchnode.ContextMenuStrip = mainWindow.contextMenuStripChannelMenu;
+
+                                nodelist.Add(patchnode);
                             }
                         }
                     }


### PR DESCRIPTION
There's this issue where if the program loads the patch channel in the XML repository, and if it's set to use Nintendo's offical updates, (built into the program, and not a custom file), it will not make a TreeNode for it, and ignores it entirely.

This PR fixes this issue, making sure it reads from the file correctly no matter what type it is.