### PR TITLE
Use forward slash instead of backslashes when exporting to binary files.

### DIFF
--- a/SatellaWave/SatellaWave/Program.cs
+++ b/SatellaWave/SatellaWave/Program.cs
@@ -2059,7 +2059,7 @@ namespace SatellaWave
             ChannelMapFile.Insert(0, 0);
             ChannelMapFile.Insert(0, 0);
 
-            FileStream mapfile = new FileStream(folderPath + "\\BSX0124-0.bin", FileMode.Create);
+            FileStream mapfile = new FileStream(folderPath + "/BSX0124-0.bin", FileMode.Create);
             mapfile.Write(ChannelMapFile.ToArray(), 0, ChannelMapFile.Count);
             mapfile.Close();
 
@@ -2073,7 +2073,7 @@ namespace SatellaWave
 
             for (int i = 0; i < fileAmount; i++)
             {
-                FileStream chnfile = new FileStream(folderPath + "\\BSX" + lci.ToString("X4") + "-" + i.ToString() + ".bin", FileMode.Create);
+                FileStream chnfile = new FileStream(folderPath + "/BSX" + lci.ToString("X4") + "-" + i.ToString() + ".bin", FileMode.Create);
 
                 chnfile.WriteByte(0); //Data Group ID
                 chnfile.WriteByte((byte)i); //Data Group Continuity

--- a/SatellaWave/SatellaWave/Properties/Resources.resx
+++ b/SatellaWave/SatellaWave/Properties/Resources.resx
@@ -119,57 +119,57 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="icon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_00" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\00.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\00.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_01" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\01.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\01.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_02" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\02.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\02.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_03" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\03.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\03.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_04" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\04.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\04.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_05" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\05.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\05.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_06" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\06.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\06.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_07" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\07.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\07.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_08" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\08.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\08.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_09" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\09.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\09.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_0A" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\10.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\10.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_0B" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\11.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\11.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_0C" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\12.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\12.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_0D" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\13.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\13.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_0E" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\14.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\14.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_0F" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\15.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\15.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Mugshot_10" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\mugshot\16.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\Mugshot\16.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>


### PR DESCRIPTION
This small PR only replaces forward slashes to backslashes when exporting repositories.  This is done to ensure better cross-platform usage when the project is built and/or running the built executable with [Mono](https://www.mono-project.com/), especially for macOS and Linux users. (like myself.)

This change doesn't effect exporting in Windows in any way, and should still work normally as intended.