### PR TITLE
Remember last BS-X export directory.

### DIFF
--- a/SatellaWave/SatellaWave/MainWindow.cs
+++ b/SatellaWave/SatellaWave/MainWindow.cs
@@ -96,6 +96,10 @@ namespace SatellaWave
 
             FolderSelect.FolderSelectDialog fsd = new FolderSelect.FolderSelectDialog();
             fsd.Title = "Select Export BS-X File Folder...";
+            if (Program.lastExportDirectory != "")
+            {
+                fsd.InitialDirectory = Program.lastExportDirectory;
+            }
             if (fsd.ShowDialog())
             {
                 //No \ at the end

--- a/SatellaWave/SatellaWave/Program.cs
+++ b/SatellaWave/SatellaWave/Program.cs
@@ -21,6 +21,7 @@ namespace SatellaWave
         public static MainWindow mainWindow;
         public static string lastSavedXMLFile = "";
         public static byte lastExportID = 0;
+        public static string lastExportDirectory = "";
 
         public static readonly string[] buildingList = {
             "Robot Tower",
@@ -1685,6 +1686,9 @@ namespace SatellaWave
 
         public static void ExportBSX(string folderPath)
         {
+            //Remember last directory path
+            lastExportDirectory = folderPath;
+
             //Check the BS-X requirements
             if (!CheckUsedChannelType(typeof(Directory)) || !CheckUsedChannelType(typeof(TownStatus)))
             {


### PR DESCRIPTION
This is done just to ease things when exporting to the same folder over and over again (mainly for testing).