### PR TITLE
Add option to reset all data on Event Plaza Editor.

### DIFF
--- a/SatellaWave/SatellaWave/EventPlazaEditor.Designer.cs
+++ b/SatellaWave/SatellaWave/EventPlazaEditor.Designer.cs
@@ -56,6 +56,7 @@
             this.resetCollisionDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetAnimationDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetBuildingMapDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetAllBuildingDataMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.buttonQuitNoSave = new System.Windows.Forms.Button();
             this.menuStrip1.SuspendLayout();
             this.panel1.SuspendLayout();
@@ -308,7 +309,8 @@
             this.resetTileDataToolStripMenuItem,
             this.resetTilesetDataToolStripMenuItem,
             this.resetCollisionDataToolStripMenuItem,
-            this.resetAnimationDataToolStripMenuItem});
+            this.resetAnimationDataToolStripMenuItem,
+            this.resetAllBuildingDataMenuItem});
             this.resetToolStripMenuItem.Name = "resetToolStripMenuItem";
             this.resetToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
             this.resetToolStripMenuItem.Text = "Reset";
@@ -347,6 +349,13 @@
             this.resetBuildingMapDataToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
             this.resetBuildingMapDataToolStripMenuItem.Text = "Reset Building Map Data";
             this.resetBuildingMapDataToolStripMenuItem.Click += new System.EventHandler(this.resetBuildingMapDataToolStripMenuItem_Click);
+            //
+            // resetAllBuildingDataMenuItem
+            //
+            this.resetAllBuildingDataMenuItem.Name = "resetAllBuildingDataMenuItem";
+            this.resetAllBuildingDataMenuItem.Size = new System.Drawing.Size(203, 22);
+            this.resetAllBuildingDataMenuItem.Text = "Reset All Data";
+            this.resetAllBuildingDataMenuItem.Click += new System.EventHandler(this.resetAllBuildingDataMenuItem_Click);
             // 
             // buttonQuitNoSave
             // 
@@ -418,6 +427,7 @@
         private System.Windows.Forms.ToolStripMenuItem resetTilesetDataToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resetCollisionDataToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resetAnimationDataToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetAllBuildingDataMenuItem;
         private System.Windows.Forms.Button buttonQuitNoSave;
     }
 }

--- a/SatellaWave/SatellaWave/EventPlazaEditor.cs
+++ b/SatellaWave/SatellaWave/EventPlazaEditor.cs
@@ -788,6 +788,31 @@ namespace SatellaWave
             }
         }
 
+        private void resetAllBuildingDataMenuItem_Click(object sender, EventArgs e)
+        {
+            if (MessageBox.Show("Are you sure you want to reset all the current data?", "Reset All Data", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                //Building Map
+                tileMap = new ushort[4 * 7];
+                doorLocations = new bool[4 * 7];
+
+                //Tile Graphics and Tile Set Data
+                InitTileData();
+                InitTilesetData();
+                InitTilesetImage();
+
+                //Collision Data
+                COLdata = new byte[0x30];
+
+                //Animation Data
+                frames.Clear();
+
+                //We're all done here, update the display.
+                UpdateTilesetImage();
+                UpdateTilemapImage();
+            }
+        }
+
         //Save
         public ushort[] GetTileMap()
         {

--- a/SatellaWave/SatellaWave/Properties/Resources.resx
+++ b/SatellaWave/SatellaWave/Properties/Resources.resx
@@ -173,18 +173,18 @@
     <value>..\Images\Mugshot\16.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="Tileset" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\images\bsxtileset.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Images\bsxtileset.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="bsxpalette" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\data\bsxpalette.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Data\bsxpalette.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="bsxtiles" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\data\bsxtiles.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Data\bsxtiles.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="bsxtileset" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\data\bsxtileset.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Data\bsxtileset.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="bsxtilesetconfig" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\data\bsxtilesetconfig.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>..\Resources\Data\bsxtilesetconfig.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
This PR adds the option to clear all the data in the Event Plaza Editor.  This is a much better option if you want to start over from scratch instead of selecting all the reset options one by one individually.