### PR TITLE
Always update display when importing graphics to Event Plaza Editor.

### DIFF
--- a/SatellaWave/SatellaWave/EventPlazaEditor.cs
+++ b/SatellaWave/SatellaWave/EventPlazaEditor.cs
@@ -680,11 +680,11 @@ namespace SatellaWave
                         }
 
                         tileMap = gfximport.GetCustomTileMap();
-
-                        InitTilesetImage();
-                        UpdateTilesetImage();
-                        UpdateTilemapImage();
                     }
+
+                    InitTilesetImage();
+                    UpdateTilesetImage();
+                    UpdateTilemapImage();
                 }
             }
         }


### PR DESCRIPTION
This PR will make the Event Plaza editor to always update the tileset and tilemap display when importing graphics instead of when only importing a custom tilemap. 

This resolves an issue where you import/replace your existing palette and tile data with newer ones (without starting over from scratch) and will not update the main editor to commentate the changeover unless you open the tileset editor (which displays the new imported data) and saving it.